### PR TITLE
Detect WAN gateway from existing default route instead of assuming .1

### DIFF
--- a/scripts/install_open5gs__networking.sh
+++ b/scripts/install_open5gs__networking.sh
@@ -37,7 +37,14 @@ fi
 
 # --- Get LTE WAN Gateway ---
 LTE_WAN_SUBNET=$(ip route show dev "$LTE_WAN_INTERFACE" | grep "proto kernel" | awk '{print $1}' | head -1)
-LTE_WAN_GATEWAY="${LTE_WAN_SUBNET%.*}.1"
+
+# Prefer the gateway from an existing default route on this interface.
+# Only fall back to guessing .1 if no default route exists yet.
+LTE_WAN_GATEWAY=$(ip route show default | awk -v dev="$LTE_WAN_INTERFACE" '$0 ~ ("dev " dev) {for (i=1;i<NF;i++) if ($i=="via") {print $(i+1); exit}}')
+if [ -z "$LTE_WAN_GATEWAY" ]; then
+    LTE_WAN_GATEWAY="${LTE_WAN_SUBNET%.*}.1"
+    log_warn "No existing default route on $LTE_WAN_INTERFACE; assuming gateway is $LTE_WAN_GATEWAY"
+fi
 
 log_info "LTE WAN subnet: $LTE_WAN_SUBNET, Gateway: $LTE_WAN_GATEWAY"
 


### PR DESCRIPTION
## Problem

`install_open5gs__networking.sh` computes the WAN gateway as the `.1` address of the WAN subnet:

```bash
LTE_WAN_GATEWAY="${LTE_WAN_SUBNET%.*}.1"
```

On any network where the gateway is not `.1` (found this in the field on a deployment where the gateway is `.254`), one of two things happens:

- Nothing answers on `.1`: the gateway ping check fails and the install aborts.
- Something else answers on `.1`: the script deletes all default routes and installs one pointing at a non-router. The box goes dark, which is fatal for remote installs.

The same wrong value gets baked into the generated `/usr/local/bin/open5gs-restore-route.sh`, so the bad route also comes back on every boot.

## Fix

Read the gateway from the interface's existing default route when one is present. Only fall back to the `.1` guess (now with a warning) when there is no default route to learn from. The restore script inherits the corrected variable, so boot-time restoration is covered by the same change.

## Testing

Verified on an Ubuntu 24.04 deployment with gateway at `.254`: install completes, default route survives, route restore service restores the correct next-hop after reboot.