### PR TITLE
Preseed iptables-persistent so the install does not hang on a debconf prompt

### DIFF
--- a/scripts/install_open5gs__packages.sh
+++ b/scripts/install_open5gs__packages.sh
@@ -55,7 +55,11 @@ dpkg -s open5gs-pcrf &> /dev/null || { log_error "open5gs-pcrf package not found
 log_info "Open5GS core packages (including PCRF) installed."
 
 log_step "Installing Required Utilities (iptables, persistence tools)"
-apt-get install -y iptables iptables-persistent yq || { log_error "Failed to install required utilities (iptables, iptables-persistent, yq)"; exit 1; }
+# Preseed iptables-persistent so it does not stop the install with an
+# interactive "save current rules?" debconf dialog.
+echo "iptables-persistent iptables-persistent/autosave_v4 boolean true" | debconf-set-selections
+echo "iptables-persistent iptables-persistent/autosave_v6 boolean true" | debconf-set-selections
+DEBIAN_FRONTEND=noninteractive apt-get install -y iptables iptables-persistent yq || { log_error "Failed to install required utilities (iptables, iptables-persistent, yq)"; exit 1; }
 if ! command -v iptables &> /dev/null; then log_error "iptables command not found after installation attempt."; exit 1; fi
 if ! command -v yq &> /dev/null; then log_error "yq command not found after installation attempt."; exit 1; fi
 log_info "Required base utilities are installed."


### PR DESCRIPTION
## Problem

The Open5GS package phase installs `iptables-persistent`, which raises the interactive debconf "Save current IPv4/IPv6 rules?" dialogs mid-install. In any non-TTY or scripted run the install hangs on that prompt indefinitely. Hit this in the field running the installer inside tmux over SSH; it sat on the whiptail dialog until someone noticed.

## Fix

Preseed both `autosave_v4` and `autosave_v6` answers with `debconf-set-selections` and install with `DEBIAN_FRONTEND=noninteractive`. Saving current rules at install time matches what the networking phase does afterwards anyway (`iptables-save > /etc/iptables/rules.v4`).

## Testing

Verified on Ubuntu 24.04: package installs with no prompt, rules persistence works, networking phase overwrites `rules.v4` with the final ruleset as before.