### PR TITLE
Fix WebUI 502: nginx proxied to [::1]:9999 but the app listens on 127.0.0.1

### DIFF
--- a/scripts/install_webui.sh
+++ b/scripts/install_webui.sh
@@ -45,7 +45,7 @@ server {
     server_name $MGMT_IP;
 
     location / {
-        proxy_pass http://[::1]:9999;  # WebUI runs on IPv6 localhost port 9999
+        proxy_pass http://127.0.0.1:9999;  # WebUI listens on IPv4 loopback port 9999
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Problem

The nginx vhost written by `install_webui.sh` proxies to `http://[::1]:9999`, but the Open5GS WebUI Node process binds the IPv4 loopback (`127.0.0.1:9999`). Result on Ubuntu 24.04: nginx returns 502 for every request while the WebUI itself is perfectly healthy. nginx error log shows `connect() failed (111: Connection refused) ... upstream: "http://[::1]:9999/"`.

## Fix

Proxy to `http://127.0.0.1:9999` to match what the app binds.

## Testing

Verified on an Ubuntu 24.04 deployment: 502 before, HTTP 200 after a `sed` of the vhost and `systemctl reload nginx`. Survives reboot.